### PR TITLE
Add initialized Dependencies struct to DependencyManagement

### DIFF
--- a/pkg/patch.go
+++ b/pkg/patch.go
@@ -125,7 +125,9 @@ func PatchProject(ctx context.Context, project *gopom.Project, patches []Patch, 
 	// If there are any missing dependencies, add them in. I guess add them
 	// to DependencyManagement?
 	if project.DependencyManagement == nil && len(missingDeps) > 0 {
-		project.DependencyManagement = &gopom.DependencyManagement{}
+		project.DependencyManagement = &gopom.DependencyManagement{
+			Dependencies: &[]gopom.Dependency{},
+		}
 	}
 	for md := range missingDeps {
 		md := md


### PR DESCRIPTION
Not sure how to test this in `patch_test.go`, but I ran into an issue with a pom that has no `dependencyManagement` section.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x626e66]

goroutine 1 [running]:
github.com/vaikas/pombump/pkg.PatchProject({0x72a4b0?, 0xc00012c200?}, 0xc0000f21a0, {0xc0000bc0f0, 0x1, 0x0?}, 0xc0000bf170)
	github.com/vaikas/pombump/pkg/patch.go:134 +0x606
github.com/vaikas/pombump/cmd/pombump.New.func2(0xc0000c6008, {0xc0000be6f0, 0x1, 0x6bc133?})
	github.com/vaikas/pombump/cmd/pombump/root.go:73 +0x245
github.com/spf13/cobra.(*Command).execute(0xc0000c6008, {0xc00012c010, 0x3, 0x3})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000c6008)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(0x72a2f0?, {0x72a4b0?, 0xc00012c200?})
	github.com/spf13/cobra@v1.8.0/command.go:1032 +0x47
main.main()
	github.com/vaikas/pombump/main.go:16 +0x96
```

I don't actually know if this is even a valid use case (bumping a dependency that isn't listed anywhere).

I'm using this [pom.xml](https://raw.githubusercontent.com/confluentinc/common-docker/master/pom.xml) and this as my `patches.yaml` file:

```
patches:
  - groupId:  org.bitbucket.b_c
    artifactId: jose4j
    version: 0.9.6
    scope: import
    type: jar
```