### PR TITLE
chore: rename module chainguard-dev/pombump

### DIFF
--- a/cmd/pombump/root.go
+++ b/cmd/pombump/root.go
@@ -8,8 +8,8 @@ import (
 	charmlog "github.com/charmbracelet/log"
 
 	"github.com/chainguard-dev/gopom"
+	"github.com/chainguard-dev/pombump/pkg"
 	"github.com/spf13/cobra"
-	"github.com/vaikas/pombump/pkg"
 	"sigs.k8s.io/release-utils/version"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vaikas/pombump
+module github.com/chainguard-dev/pombump
 
 go 1.21.5
 require (

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/vaikas/pombump/cmd/pombump"
+	"github.com/chainguard-dev/pombump/cmd/pombump"
 )
 
 func main() {


### PR DESCRIPTION
This PR renames the module as `github.com/chainguard-dev/pombump`.

Fixes #18 