### PR TITLE
fix(pkg/patch.go): fix nil pointer dereference

### DIFF
--- a/pkg/patch.go
+++ b/pkg/patch.go
@@ -106,7 +106,7 @@ func PatchProject(ctx context.Context, project *gopom.Project, patches []Patch, 
 
 	// Note that we do not patch scope, or type, since they should already be
 	// configured correctly.
-	if project.DependencyManagement != nil {
+	if project.DependencyManagement != nil && project.DependencyManagement.Dependencies != nil {
 		for i, dep := range *project.DependencyManagement.Dependencies {
 			log.Debugf("Checking DM DEP: %s.%s:%s", dep.GroupID, dep.ArtifactID, dep.Version)
 			for _, patch := range patches {
@@ -122,11 +122,14 @@ func PatchProject(ctx context.Context, project *gopom.Project, patches []Patch, 
 		}
 	}
 
-	// If there are any missing dependencies, add them in. I guess add them
-	// to DependencyManagement?
-	if project.DependencyManagement == nil && len(missingDeps) > 0 {
-		project.DependencyManagement = &gopom.DependencyManagement{
-			Dependencies: &[]gopom.Dependency{},
+	// Initialize DependencyManagement if needed for missing dependencies
+	if len(missingDeps) > 0 {
+		if project.DependencyManagement == nil {
+			project.DependencyManagement = &gopom.DependencyManagement{
+				Dependencies: &[]gopom.Dependency{},
+			}
+		} else if project.DependencyManagement.Dependencies == nil {
+			project.DependencyManagement.Dependencies = &[]gopom.Dependency{}
 		}
 	}
 	for md := range missingDeps {

--- a/pkg/patch_test.go
+++ b/pkg/patch_test.go
@@ -176,6 +176,26 @@ func checkProps(t *testing.T, project *gopom.Project, props map[string]string) {
 	}
 }
 
+func TestNilPointerDereferenceDependenciesRegression(t *testing.T) {
+	// Test the specific case that caused the nil pointer panic:
+	// zipkin.pom.xml has a dependencyManagement section but no dependencies element
+	project, err := gopom.Parse("testdata/zipkin.pom.xml")
+	if err != nil {
+		t.Fatalf("Failed to parse zipkin.pom.xml: %v", err)
+	}
+
+	patches, err := ParsePatches("testdata/zipkin-pombump-deps.yaml", "")
+	if err != nil {
+		t.Fatalf("Failed to parse zipkin-pombump-deps.yaml: %v", err)
+	}
+
+	// This should not panic
+	_, err = PatchProject(context.Background(), project, patches, nil)
+	if err != nil {
+		t.Errorf("PatchProject failed: %v", err)
+	}
+}
+
 func lessPatch(a, b Patch) bool {
 	return a.ArtifactID < b.ArtifactID && a.GroupID < b.GroupID && a.Version < b.Version && a.Scope < b.Scope
 }


### PR DESCRIPTION
Ensure that we are not referencing
project.DependencyManagement.Dependencies when it is nil. Initialize project.DependencyManagement or
project.DependencyManagement.Dependencies if any of them is empty.