### PR TITLE
feat: Add POM analyzer for property-based dependency detection

### DIFF
--- a/cmd/pombump/analyze.go
+++ b/cmd/pombump/analyze.go
@@ -1,0 +1,266 @@
+package pombump
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/chainguard-dev/gopom"
+	"github.com/chainguard-dev/pombump/pkg"
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+)
+
+type analyzeCLIFlags struct {
+	patches          string
+	patchFile        string
+	outputFormat     string
+	outputDeps       string
+	outputProperties string
+	searchProperties bool
+}
+
+var analyzeFlags analyzeCLIFlags
+
+func AnalyzeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "analyze <pom-file>",
+		Short: "Analyze a POM file to understand dependency structure",
+		Long: `Analyze a POM file to understand how dependencies are defined.
+This command helps determine whether to use direct dependency patches or property updates.
+
+Examples:
+  # Analyze a POM and show report
+  pombump analyze pom.xml
+
+  # Analyze with proposed patches to see recommendations
+  pombump analyze pom.xml --patches "io.netty@netty-codec-http@4.1.94.Final"
+
+  # Analyze with multiple patches
+  pombump analyze pom.xml --patches "io.netty@netty-codec-http@4.1.94.Final io.netty@netty-handler@4.1.94.Final"
+
+  # Generate patch files based on analysis (appends to existing files)
+  pombump analyze pom.xml --patches "io.netty@netty-codec-http@4.1.94.Final" \
+    --output-deps pombump-deps.yaml \
+    --output-properties pombump-properties.yaml
+    
+  # Search for properties in entire project tree
+  pombump analyze pom.xml --search-properties --patches "org.assertj@assertj-core@3.25.0"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Analyze the project (with property search if requested)
+			var analysis *pkg.AnalysisResult
+			var err error
+			
+			if analyzeFlags.searchProperties {
+				// Use enhanced analysis that searches for properties
+				analysis, err = pkg.AnalyzeProjectPath(cmd.Context(), args[0])
+				if err != nil {
+					return fmt.Errorf("failed to analyze project: %w", err)
+				}
+			} else {
+				// Use basic analysis (single file only)
+				parsedPom, err := gopom.Parse(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to parse POM file: %w", err)
+				}
+				
+				analysis, err = pkg.AnalyzeProject(cmd.Context(), parsedPom)
+				if err != nil {
+					return fmt.Errorf("failed to analyze project: %w", err)
+				}
+			}
+
+			// If patches are provided, analyze them
+			if analyzeFlags.patches != "" || analyzeFlags.patchFile != "" {
+				patches, err := pkg.ParsePatches(cmd.Context(), analyzeFlags.patchFile, analyzeFlags.patches)
+				if err != nil {
+					return fmt.Errorf("failed to parse patches: %w", err)
+				}
+
+				directPatches, propertyPatches := pkg.PatchStrategy(cmd.Context(), analysis, patches)
+
+				// Output recommendations
+				if analyzeFlags.outputFormat == "yaml" {
+					outputYAML(directPatches, propertyPatches)
+				} else {
+					outputAnalysisReport(analysis, directPatches, propertyPatches)
+				}
+
+				// Write files if requested
+				if analyzeFlags.outputDeps != "" && len(directPatches) > 0 {
+					if err := writeDepsFile(analyzeFlags.outputDeps, directPatches); err != nil {
+						return fmt.Errorf("failed to write deps file: %w", err)
+					}
+					fmt.Printf("\nWrote %d patches to %s\n", len(directPatches), analyzeFlags.outputDeps)
+				}
+
+				if analyzeFlags.outputProperties != "" && len(propertyPatches) > 0 {
+					if err := writePropertiesFile(analyzeFlags.outputProperties, propertyPatches); err != nil {
+						return fmt.Errorf("failed to write properties file: %w", err)
+					}
+					fmt.Printf("Wrote %d properties to %s\n", len(propertyPatches), analyzeFlags.outputProperties)
+				}
+			} else {
+				// Just output the analysis report
+				fmt.Println(analysis.AnalysisReport())
+			}
+
+			return nil
+		},
+	}
+
+	flagSet := cmd.Flags()
+	flagSet.StringVar(&analyzeFlags.patches, "patches", "", "Space-separated list of patches to analyze (groupID@artifactID@version)")
+	flagSet.StringVar(&analyzeFlags.patchFile, "patch-file", "", "File containing patches to analyze")
+	flagSet.StringVar(&analyzeFlags.outputFormat, "output", "human", "Output format: human or yaml")
+	flagSet.StringVar(&analyzeFlags.outputDeps, "output-deps", "", "Write recommended dependency patches to this file")
+	flagSet.StringVar(&analyzeFlags.outputProperties, "output-properties", "", "Write recommended property patches to this file")
+	flagSet.BoolVar(&analyzeFlags.searchProperties, "search-properties", false, "Search for properties in nearby POM files")
+
+	return cmd
+}
+
+func outputAnalysisReport(analysis *pkg.AnalysisResult, directPatches []pkg.Patch, propertyPatches map[string]string) {
+	fmt.Println("")
+	fmt.Println("Patch Recommendations")
+	fmt.Println("=====================")
+	fmt.Println("")
+
+	if len(propertyPatches) > 0 {
+		fmt.Println("Property Updates:")
+		fmt.Println("-----------------")
+		for prop, version := range propertyPatches {
+			currentValue := analysis.Properties[prop]
+			if currentValue != "" {
+				fmt.Printf("  %s: %s -> %s\n", prop, currentValue, version)
+			} else {
+				fmt.Printf("  %s: (new) -> %s\n", prop, version)
+			}
+
+			// Show affected dependencies
+			affected := analysis.GetAffectedDependencies(prop)
+			if len(affected) > 0 {
+				fmt.Printf("    Affects %d dependencies:\n", len(affected))
+				for _, dep := range affected {
+					fmt.Printf("      - %s:%s\n", dep.GroupID, dep.ArtifactID)
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	if len(directPatches) > 0 {
+		fmt.Println("Direct Dependency Updates:")
+		fmt.Println("--------------------------")
+		for _, patch := range directPatches {
+			depKey := fmt.Sprintf("%s:%s", patch.GroupID, patch.ArtifactID)
+			if dep, exists := analysis.Dependencies[depKey]; exists {
+				fmt.Printf("  %s:%s: %s -> %s\n",
+					patch.GroupID, patch.ArtifactID, dep.Version, patch.Version)
+			} else {
+				fmt.Printf("  %s:%s: (new) -> %s\n",
+					patch.GroupID, patch.ArtifactID, patch.Version)
+			}
+		}
+	}
+
+	fmt.Printf("\nSummary: %d property updates, %d direct dependency updates\n",
+		len(propertyPatches), len(directPatches))
+}
+
+func outputYAML(directPatches []pkg.Patch, propertyPatches map[string]string) {
+	result := map[string]interface{}{}
+
+	if len(directPatches) > 0 {
+		result["patches"] = directPatches
+	}
+
+	if len(propertyPatches) > 0 {
+		props := []pkg.PropertyPatch{}
+		for k, v := range propertyPatches {
+			props = append(props, pkg.PropertyPatch{
+				Property: k,
+				Value:    v,
+			})
+		}
+		result["properties"] = props
+	}
+
+	output, _ := yaml.Marshal(result)
+	fmt.Println(string(output))
+}
+
+func writeDepsFile(filename string, patches []pkg.Patch) error {
+	// Read existing file if it exists
+	var existingList pkg.PatchList
+	if data, err := os.ReadFile(filename); err == nil {
+		if err := yaml.Unmarshal(data, &existingList); err != nil {
+			// If unmarshal fails, start fresh
+			existingList = pkg.PatchList{Patches: []pkg.Patch{}}
+		}
+	}
+
+	// Create a map to track existing patches by groupID:artifactID
+	patchMap := make(map[string]pkg.Patch)
+	for _, p := range existingList.Patches {
+		key := fmt.Sprintf("%s:%s", p.GroupID, p.ArtifactID)
+		patchMap[key] = p
+	}
+
+	// Update existing or add new patches
+	for _, patch := range patches {
+		key := fmt.Sprintf("%s:%s", patch.GroupID, patch.ArtifactID)
+		patchMap[key] = patch // This will update if exists, or add if new
+	}
+
+	// Convert map back to slice
+	var finalPatches []pkg.Patch
+	for _, patch := range patchMap {
+		finalPatches = append(finalPatches, patch)
+	}
+
+	finalList := pkg.PatchList{Patches: finalPatches}
+	data, err := yaml.Marshal(finalList)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
+}
+
+func writePropertiesFile(filename string, properties map[string]string) error {
+	// Read existing file if it exists
+	var existingList pkg.PropertyList
+	if data, err := os.ReadFile(filename); err == nil {
+		if err := yaml.Unmarshal(data, &existingList); err != nil {
+			// If unmarshal fails, start fresh
+			existingList = pkg.PropertyList{Properties: []pkg.PropertyPatch{}}
+		}
+	}
+
+	// Create a map to track existing properties
+	propMap := make(map[string]string)
+	for _, p := range existingList.Properties {
+		propMap[p.Property] = p.Value
+	}
+
+	// Update existing or add new properties
+	for k, v := range properties {
+		propMap[k] = v // This will update if exists, or add if new
+	}
+
+	// Convert map back to slice
+	var finalProperties []pkg.PropertyPatch
+	for k, v := range propMap {
+		finalProperties = append(finalProperties, pkg.PropertyPatch{
+			Property: k,
+			Value:    v,
+		})
+	}
+
+	finalList := pkg.PropertyList{Properties: finalProperties}
+	data, err := yaml.Marshal(finalList)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
+}

--- a/cmd/pombump/root.go
+++ b/cmd/pombump/root.go
@@ -87,6 +87,7 @@ func New() *cobra.Command {
 	cmd.PersistentFlags().Var(&level, "log-level", "log level (e.g. debug, info, warn, error)")
 
 	cmd.AddCommand(version.WithFont("starwars"))
+	cmd.AddCommand(AnalyzeCmd())
 
 	cmd.DisableAutoGenTag = true
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	sigs.k8s.io/release-utils v0.11.1
 )
 
@@ -21,6 +22,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
@@ -36,4 +39,5 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/analyzer.go
+++ b/pkg/analyzer.go
@@ -1,0 +1,486 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/gopom"
+)
+
+// DependencyInfo contains information about how a dependency is defined
+type DependencyInfo struct {
+	GroupID            string
+	ArtifactID         string
+	Version            string
+	UsesProperty       bool
+	PropertyName       string
+	PropertyUsageCount int
+}
+
+// AnalysisResult contains the analysis of a POM project
+type AnalysisResult struct {
+	// Dependencies maps groupId:artifactId to dependency info
+	Dependencies map[string]*DependencyInfo
+	// PropertyUsageCounts tracks how many times each property is used
+	PropertyUsageCounts map[string]int
+	// Properties contains the actual property values from the POM
+	Properties map[string]string
+}
+
+// AnalyzeProject analyzes a POM project to understand how dependencies are defined
+func AnalyzeProject(ctx context.Context, project *gopom.Project) (*AnalysisResult, error) {
+	log := clog.FromContext(ctx)
+
+	if project == nil {
+		return nil, fmt.Errorf("project is nil")
+	}
+
+	result := &AnalysisResult{
+		Dependencies:        make(map[string]*DependencyInfo),
+		PropertyUsageCounts: make(map[string]int),
+		Properties:          make(map[string]string),
+	}
+
+	// Extract existing properties
+	result.Properties = extractPropertiesFromProject(project)
+
+	// Analyze regular dependencies
+	if project.Dependencies != nil {
+		for _, dep := range *project.Dependencies {
+			analyzeDependency(ctx, dep, result)
+		}
+	}
+
+	// Analyze dependency management section
+	if project.DependencyManagement != nil && project.DependencyManagement.Dependencies != nil {
+		for _, dep := range *project.DependencyManagement.Dependencies {
+			analyzeDependency(ctx, dep, result)
+		}
+	}
+
+	log.Infof("Analysis complete: found %d dependencies, %d using properties",
+		len(result.Dependencies), countPropertiesUsage(result))
+
+	return result, nil
+}
+
+// AnalyzeProjectPath analyzes a POM file and searches for properties in nearby POM files
+func AnalyzeProjectPath(ctx context.Context, pomPath string) (*AnalysisResult, error) {
+	log := clog.FromContext(ctx)
+	
+	// Get absolute path for consistency
+	absPomPath, err := filepath.Abs(pomPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	
+	log.Debugf("Analyzing POM with property search: %s", absPomPath)
+	
+	// First analyze the main POM
+	project, err := gopom.Parse(absPomPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse POM file: %w", err)
+	}
+	
+	result, err := AnalyzeProject(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	
+	log.Debugf("Main POM analysis found %d properties, %d dependencies", 
+		len(result.Properties), len(result.Dependencies))
+	
+	// Search for additional properties in nearby POMs
+	dir := filepath.Dir(absPomPath)
+	additionalProps := searchForProperties(ctx, dir, absPomPath)
+	
+	log.Debugf("Property search found %d additional properties", len(additionalProps))
+	
+	// Merge additional properties
+	mergeProperties(ctx, result.Properties, additionalProps, "nearby POM")
+	
+	log.Infof("Total after merge: %d properties, %d dependencies", 
+		len(result.Properties), len(result.Dependencies))
+	
+	return result, nil
+}
+
+// analyzeDependency analyzes a single dependency
+func analyzeDependency(ctx context.Context, dep gopom.Dependency, result *AnalysisResult) {
+	log := clog.FromContext(ctx)
+
+	depKey := fmt.Sprintf("%s:%s", dep.GroupID, dep.ArtifactID)
+
+	info := &DependencyInfo{
+		GroupID:    dep.GroupID,
+		ArtifactID: dep.ArtifactID,
+		Version:    dep.Version,
+	}
+
+	// Check if version uses a property reference
+	if strings.HasPrefix(dep.Version, "${") && strings.HasSuffix(dep.Version, "}") {
+		propertyName := strings.TrimSuffix(strings.TrimPrefix(dep.Version, "${"), "}")
+		info.UsesProperty = true
+		info.PropertyName = propertyName
+		result.PropertyUsageCounts[propertyName]++
+		info.PropertyUsageCount = result.PropertyUsageCounts[propertyName]
+
+		log.Debugf("Dependency %s uses property %s (total usage: %d)",
+			depKey, propertyName, info.PropertyUsageCount)
+	}
+
+	result.Dependencies[depKey] = info
+}
+
+// countPropertiesUsage counts how many dependencies use properties
+func countPropertiesUsage(result *AnalysisResult) int {
+	count := 0
+	for _, dep := range result.Dependencies {
+		if dep.UsesProperty {
+			count++
+		}
+	}
+	return count
+}
+
+// ShouldUseProperty determines if a specific dependency should be updated via property
+func (result *AnalysisResult) ShouldUseProperty(groupID, artifactID string) (bool, string) {
+	depKey := fmt.Sprintf("%s:%s", groupID, artifactID)
+
+	if info, exists := result.Dependencies[depKey]; exists {
+		if info.UsesProperty {
+			return true, info.PropertyName
+		}
+	}
+
+	// No property reference found
+	return false, ""
+}
+
+// PatchStrategy recommends whether to use properties or direct patches
+// Returns direct patches and property patches separately
+func PatchStrategy(ctx context.Context, result *AnalysisResult, patches []Patch) ([]Patch, map[string]string) {
+	log := clog.FromContext(ctx)
+
+	log.Debugf("Determining patch strategy for %d patches", len(patches))
+	log.Debugf("Available properties: %d, Dependencies: %d", len(result.Properties), len(result.Dependencies))
+
+	directPatches := []Patch{}
+	propertyPatches := make(map[string]string)
+	missingProperties := []string{}
+
+	for _, patch := range patches {
+		depKey := fmt.Sprintf("%s:%s", patch.GroupID, patch.ArtifactID)
+		useProperty, propertyName := result.ShouldUseProperty(patch.GroupID, patch.ArtifactID)
+		
+		log.Debugf("Checking patch for %s version %s", depKey, patch.Version)
+
+		if useProperty && propertyName != "" {
+			log.Debugf("  -> Dependency %s uses property ${%s}", depKey, propertyName)
+			
+			// Check if we already have this property
+			if existingVersion, exists := propertyPatches[propertyName]; exists {
+				log.Warnf("Property %s already set to %s, requested %s for %s:%s",
+					propertyName, existingVersion, patch.Version, patch.GroupID, patch.ArtifactID)
+				// Compare versions and use the newer one
+			} else {
+				propertyPatches[propertyName] = patch.Version
+				
+				// Check if this property is actually defined somewhere
+				if currentValue, exists := result.Properties[propertyName]; exists {
+					log.Infof("Will update property %s from %s to %s", propertyName, currentValue, patch.Version)
+				} else {
+					log.Warnf("Property %s is referenced but not found in project - it may be defined in an external parent POM", propertyName)
+					missingProperties = append(missingProperties, propertyName)
+				}
+			}
+		} else {
+			if _, exists := result.Dependencies[depKey]; exists {
+				log.Debugf("  -> Dependency %s found but doesn't use properties", depKey)
+			} else {
+				log.Debugf("  -> Dependency %s not found in POM (may be from BOM or new)", depKey)
+			}
+			directPatches = append(directPatches, patch)
+			log.Infof("Will directly patch %s:%s to %s", patch.GroupID, patch.ArtifactID, patch.Version)
+		}
+	}
+
+	if len(missingProperties) > 0 {
+		log.Warnf("The following properties are referenced but not found in the project: %s", strings.Join(missingProperties, ", "))
+		log.Warnf("These properties may be defined in an external parent POM or imported dependency")
+	}
+
+	log.Infof("Strategy: %d direct patches, %d property updates", len(directPatches), len(propertyPatches))
+
+	return directPatches, propertyPatches
+}
+
+// GetAffectedDependencies returns all dependencies that would be affected by updating a property
+func (result *AnalysisResult) GetAffectedDependencies(propertyName string) []*DependencyInfo {
+	affected := []*DependencyInfo{}
+
+	for _, dep := range result.Dependencies {
+		if dep.UsesProperty && dep.PropertyName == propertyName {
+			affected = append(affected, dep)
+		}
+	}
+
+	return affected
+}
+
+// AnalysisReport generates a human-readable report of the analysis
+func (result *AnalysisResult) AnalysisReport() string {
+	var report strings.Builder
+
+	report.WriteString("POM Analysis Report\n")
+	report.WriteString("===================\n\n")
+
+	report.WriteString(fmt.Sprintf("Total dependencies: %d\n", len(result.Dependencies)))
+	report.WriteString(fmt.Sprintf("Dependencies using properties: %d\n", countPropertiesUsage(result)))
+	report.WriteString(fmt.Sprintf("Total properties defined: %d\n\n", len(result.Properties)))
+
+	if len(result.PropertyUsageCounts) > 0 {
+		report.WriteString("Property Usage:\n")
+		report.WriteString("---------------\n")
+		for prop, count := range result.PropertyUsageCounts {
+			currentValue := result.Properties[prop]
+			if currentValue != "" {
+				report.WriteString(fmt.Sprintf("  %s = %s (used by %d dependencies)\n", prop, currentValue, count))
+			} else {
+				report.WriteString(fmt.Sprintf("  %s (used by %d dependencies) - NOT DEFINED\n", prop, count))
+			}
+		}
+		report.WriteString("\n")
+	}
+
+	// List dependencies that use properties
+	depsWithProps := []*DependencyInfo{}
+	for _, dep := range result.Dependencies {
+		if dep.UsesProperty {
+			depsWithProps = append(depsWithProps, dep)
+		}
+	}
+
+	if len(depsWithProps) > 0 {
+		report.WriteString("Dependencies Using Properties:\n")
+		report.WriteString("-------------------------------\n")
+		for _, dep := range depsWithProps {
+			report.WriteString(fmt.Sprintf("  %s:%s -> ${%s}\n",
+				dep.GroupID, dep.ArtifactID, dep.PropertyName))
+		}
+	}
+
+	return report.String()
+}
+
+// searchForProperties recursively searches for all properties in the project
+func searchForProperties(ctx context.Context, startDir string, excludePath string) map[string]string {
+	log := clog.FromContext(ctx)
+	properties := make(map[string]string)
+	pomFilesChecked := 0
+	pomFilesSkipped := 0
+	
+	// First, find the project root (go up until we find the topmost pom.xml)
+	projectRoot := findProjectRoot(startDir)
+	log.Debugf("Starting property search from project root: %s", projectRoot)
+	log.Debugf("Excluding file: %s", excludePath)
+	
+	// Recursively walk the entire project tree
+	err := filepath.Walk(projectRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip errors, continue walking
+		}
+		
+		// Skip hidden directories and common non-source directories
+		if info.IsDir() {
+			if isSkippableDirectory(info.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		
+		// Only process XML files (POMs can have any name)
+		if !strings.HasSuffix(info.Name(), ".xml") {
+			return nil
+		}
+		
+		// Skip the file we're already analyzing
+		if absPath, _ := filepath.Abs(path); absPath == excludePath {
+			log.Debugf("Skipping excluded file: %s", path)
+			pomFilesSkipped++
+			return nil
+		}
+		
+		// Try to parse as POM
+		project, err := gopom.Parse(path)
+		if err != nil {
+			// Not a valid POM, skip
+			log.Debugf("Not a valid POM (skipping): %s", path)
+			return nil
+		}
+		
+		pomFilesChecked++
+		log.Debugf("Checking POM file %d: %s", pomFilesChecked, path)
+		
+		// Extract properties if they exist
+		pomProperties := extractPropertiesFromProject(project)
+		for k, v := range pomProperties {
+			if _, exists := properties[k]; !exists {
+				properties[k] = v
+				relPath, _ := filepath.Rel(projectRoot, path)
+				log.Infof("Found property %s = %s in %s", k, v, relPath)
+			}
+		}
+		
+		return nil
+	})
+	
+	if err != nil {
+		log.Warnf("Error walking project tree: %v", err)
+	}
+	
+	log.Infof("Property search complete: checked %d POM files, skipped %d, found %d unique properties", 
+		pomFilesChecked, pomFilesSkipped, len(properties))
+	
+	if log.Enabled(context.Background(), slog.LevelDebug) {
+		log.Debugf("Properties found: %v", properties)
+	}
+	
+	return properties
+}
+
+// findProjectRoot finds the root of the Maven project by looking for the topmost pom.xml
+func findProjectRoot(startDir string) string {
+	current := startDir
+	projectRoot := startDir
+	levels := 0
+	
+	// Go up the directory tree looking for pom.xml files
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached filesystem root
+			break
+		}
+		
+		parentPom := filepath.Join(parent, "pom.xml")
+		if _, err := os.Stat(parentPom); err == nil {
+			// Found a pom.xml in parent, this might be the project root
+			projectRoot = parent
+			current = parent
+			levels++
+		} else {
+			// No pom.xml in parent, we've found the project root
+			break
+		}
+	}
+	
+	if levels > 0 {
+		// Only log if we actually traversed up
+		clog.FromContext(context.Background()).Debugf("Found project root %d levels up from %s: %s", 
+			levels, startDir, projectRoot)
+	}
+	
+	return projectRoot
+}
+
+// FindPropertyLocation searches for where a specific property is defined in the project
+func FindPropertyLocation(ctx context.Context, startDir string, propertyName string) (string, string, error) {
+	log := clog.FromContext(ctx)
+	
+	projectRoot := findProjectRoot(startDir)
+	log.Debugf("Searching for property %s starting from project root: %s", propertyName, projectRoot)
+	
+	var foundPath string
+	var foundValue string
+	pomFilesChecked := 0
+	
+	// Recursively search the entire project
+	err := filepath.Walk(projectRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || foundPath != "" {
+			return nil
+		}
+		
+		// Skip hidden directories and common non-source directories
+		if info.IsDir() {
+			if isSkippableDirectory(info.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		
+		// Only process XML files (POMs can have any name)
+		if !strings.HasSuffix(info.Name(), ".xml") {
+			return nil
+		}
+		
+		project, err := gopom.Parse(path)
+		if err != nil {
+			return nil
+		}
+		
+		pomFilesChecked++
+		
+		pomProperties := extractPropertiesFromProject(project)
+		if value, exists := pomProperties[propertyName]; exists {
+			foundPath = path
+			foundValue = value
+			relPath, _ := filepath.Rel(projectRoot, path)
+			log.Infof("Found property %s = %s in %s", propertyName, value, relPath)
+			return filepath.SkipDir // Stop searching
+		}
+		
+		return nil
+	})
+	
+	if err != nil {
+		log.Debugf("Error searching for property: %v", err)
+	}
+	
+	if foundPath != "" {
+		return foundPath, foundValue, nil
+	}
+	
+	// Property not found in project
+	log.Warnf("Property '%s' not found after searching %d POM files in project", propertyName, pomFilesChecked)
+	log.Warnf("This property may be defined in an external parent POM or imported from a dependency")
+	
+	return "", "", fmt.Errorf("property '%s' not found in project (searched %d POM files); it may be defined in an external parent POM", propertyName, pomFilesChecked)
+}
+
+// mergeProperties merges source properties into target, logging new additions
+func mergeProperties(ctx context.Context, target, source map[string]string, sourceDesc string) {
+	log := clog.FromContext(ctx)
+	for k, v := range source {
+		if _, exists := target[k]; !exists {
+			target[k] = v
+			log.Infof("Found property %s = %s in %s", k, v, sourceDesc)
+		}
+	}
+}
+
+// isSkippableDirectory checks if a directory should be skipped during traversal
+func isSkippableDirectory(name string) bool {
+	return strings.HasPrefix(name, ".") || 
+		name == "target" || 
+		name == "node_modules" ||
+		name == "build" ||
+		name == "dist" ||
+		name == "out"
+}
+
+// extractPropertiesFromProject extracts properties from a parsed POM project
+func extractPropertiesFromProject(project *gopom.Project) map[string]string {
+	properties := make(map[string]string)
+	if project != nil && project.Properties != nil && project.Properties.Entries != nil {
+		for k, v := range project.Properties.Entries {
+			properties[k] = v
+		}
+	}
+	return properties
+}

--- a/pkg/analyzer_search_test.go
+++ b/pkg/analyzer_search_test.go
@@ -1,0 +1,414 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeProjectPath(t *testing.T) {
+	// Create a temporary directory structure with multiple POMs
+	tmpDir := t.TempDir()
+	
+	// Create project structure:
+	// /
+	// ├── pom.xml (root)
+	// ├── parent/
+	// │   └── pom.xml (defines properties)
+	// ├── module1/
+	// │   └── pom.xml (uses properties)
+	// └── module2/
+	//     └── submodule/
+	//         └── pom.xml
+	
+	// Root POM
+	rootPom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <groupId>com.example</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    
+    <properties>
+        <project.version>1.0.0</project.version>
+    </properties>
+    
+    <modules>
+        <module>parent</module>
+        <module>module1</module>
+        <module>module2</module>
+    </modules>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "pom.xml"), []byte(rootPom), 0644))
+	
+	// Parent POM with properties
+	parentDir := filepath.Join(tmpDir, "parent")
+	require.NoError(t, os.MkdirAll(parentDir, 0755))
+	parentPom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>root</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>parent</artifactId>
+    
+    <properties>
+        <netty.version>4.1.94.Final</netty.version>
+        <jackson.version>2.15.2</jackson.version>
+        <slf4j.version>1.7.30</slf4j.version>
+    </properties>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "pom.xml"), []byte(parentPom), 0644))
+	
+	// Module1 POM using properties
+	module1Dir := filepath.Join(tmpDir, "module1")
+	require.NoError(t, os.MkdirAll(module1Dir, 0755))
+	module1Pom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>module1</artifactId>
+    
+    <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+        </dependency>
+    </dependencies>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(module1Dir, "pom.xml"), []byte(module1Pom), 0644))
+	
+	// Module2 with submodule
+	module2Dir := filepath.Join(tmpDir, "module2", "submodule")
+	require.NoError(t, os.MkdirAll(module2Dir, 0755))
+	module2Pom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <artifactId>submodule</artifactId>
+    <version>1.0.0</version>
+    
+    <properties>
+        <local.property>local-value</local.property>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(module2Dir, "pom.xml"), []byte(module2Pom), 0644))
+	
+	// Test analyzing module1 with property search
+	ctx := context.Background()
+	module1PomPath := filepath.Join(module1Dir, "pom.xml")
+	
+	t.Run("analyze with property search", func(t *testing.T) {
+		result, err := AnalyzeProjectPath(ctx, module1PomPath)
+		require.NoError(t, err)
+		
+		// Should find dependencies
+		assert.Equal(t, 3, len(result.Dependencies))
+		
+		// Should find properties from parent POM
+		assert.Contains(t, result.Properties, "netty.version")
+		assert.Equal(t, "4.1.94.Final", result.Properties["netty.version"])
+		assert.Contains(t, result.Properties, "jackson.version")
+		assert.Equal(t, "2.15.2", result.Properties["jackson.version"])
+		
+		// Should also find properties from root POM
+		assert.Contains(t, result.Properties, "project.version")
+		
+		// Should detect property usage
+		usesProp, propName := result.ShouldUseProperty("io.netty", "netty-handler")
+		assert.True(t, usesProp)
+		assert.Equal(t, "netty.version", propName)
+	})
+	
+	t.Run("patch strategy with found properties", func(t *testing.T) {
+		result, err := AnalyzeProjectPath(ctx, module1PomPath)
+		require.NoError(t, err)
+		
+		patches := []Patch{
+			{
+				GroupID:    "io.netty",
+				ArtifactID: "netty-handler",
+				Version:    "4.1.118.Final",
+			},
+			{
+				GroupID:    "junit",
+				ArtifactID: "junit",
+				Version:    "4.13.3",
+			},
+		}
+		
+		directPatches, propertyPatches := PatchStrategy(ctx, result, patches)
+		
+		// netty should use property
+		assert.Len(t, propertyPatches, 1)
+		assert.Equal(t, "4.1.118.Final", propertyPatches["netty.version"])
+		
+		// junit should be direct
+		assert.Len(t, directPatches, 1)
+		assert.Equal(t, "junit", directPatches[0].ArtifactID)
+	})
+}
+
+func TestFindProjectRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create nested structure
+	// /tmp/
+	// ├── project/
+	// │   ├── pom.xml
+	// │   └── module/
+	// │       ├── pom.xml
+	// │       └── submodule/
+	// │           └── pom.xml
+	// └── other/
+	
+	projectDir := filepath.Join(tmpDir, "project")
+	moduleDir := filepath.Join(projectDir, "module")
+	submoduleDir := filepath.Join(moduleDir, "submodule")
+	otherDir := filepath.Join(tmpDir, "other")
+	
+	require.NoError(t, os.MkdirAll(submoduleDir, 0755))
+	require.NoError(t, os.MkdirAll(otherDir, 0755))
+	
+	// Create POM files
+	pomContent := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <artifactId>test</artifactId>
+    <version>1.0.0</version>
+</project>`
+	
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "pom.xml"), []byte(pomContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "pom.xml"), []byte(pomContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(submoduleDir, "pom.xml"), []byte(pomContent), 0644))
+	
+	tests := []struct {
+		name     string
+		startDir string
+		wantRoot string
+	}{
+		{
+			name:     "from project root",
+			startDir: projectDir,
+			wantRoot: projectDir,
+		},
+		{
+			name:     "from module",
+			startDir: moduleDir,
+			wantRoot: projectDir,
+		},
+		{
+			name:     "from submodule",
+			startDir: submoduleDir,
+			wantRoot: projectDir,
+		},
+		{
+			name:     "from directory without pom",
+			startDir: otherDir,
+			wantRoot: otherDir,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findProjectRoot(tt.startDir)
+			assert.Equal(t, tt.wantRoot, got)
+		})
+	}
+}
+
+func TestFindPropertyLocation(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create project structure
+	parentDir := filepath.Join(tmpDir, "parent")
+	require.NoError(t, os.MkdirAll(parentDir, 0755))
+	
+	// Root POM with some properties
+	rootPom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <properties>
+        <root.property>root-value</root.property>
+    </properties>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "pom.xml"), []byte(rootPom), 0644))
+	
+	// Parent POM with different properties
+	parentPom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <properties>
+        <parent.property>parent-value</parent.property>
+        <shared.property>shared-value</shared.property>
+    </properties>
+</project>`
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "pom.xml"), []byte(parentPom), 0644))
+	
+	ctx := context.Background()
+	
+	t.Run("find property in root", func(t *testing.T) {
+		path, value, err := FindPropertyLocation(ctx, parentDir, "root.property")
+		require.NoError(t, err)
+		assert.Contains(t, path, "pom.xml")
+		assert.Equal(t, "root-value", value)
+	})
+	
+	t.Run("find property in parent", func(t *testing.T) {
+		path, value, err := FindPropertyLocation(ctx, parentDir, "parent.property")
+		require.NoError(t, err)
+		assert.Contains(t, path, filepath.Join("parent", "pom.xml"))
+		assert.Equal(t, "parent-value", value)
+	})
+	
+	t.Run("property not found", func(t *testing.T) {
+		_, _, err := FindPropertyLocation(ctx, parentDir, "nonexistent.property")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in project")
+		assert.Contains(t, err.Error(), "external parent POM")
+	})
+}
+
+func TestSearchForPropertiesSkipsHiddenAndBuildDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create directories that should be skipped
+	hiddenDir := filepath.Join(tmpDir, ".git")
+	targetDir := filepath.Join(tmpDir, "target")
+	nodeDir := filepath.Join(tmpDir, "node_modules")
+	validDir := filepath.Join(tmpDir, "src")
+	
+	for _, dir := range []string{hiddenDir, targetDir, nodeDir, validDir} {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+	
+	// Create POMs in each directory
+	pomContent := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <properties>
+        <test.property>%s</test.property>
+    </properties>
+</project>`
+	
+	// This should be skipped
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hiddenDir, "pom.xml"),
+		[]byte(fmt.Sprintf(pomContent, "hidden")),
+		0644))
+	
+	// This should be skipped
+	require.NoError(t, os.WriteFile(
+		filepath.Join(targetDir, "pom.xml"),
+		[]byte(fmt.Sprintf(pomContent, "target")),
+		0644))
+	
+	// This should be skipped
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nodeDir, "pom.xml"),
+		[]byte(fmt.Sprintf(pomContent, "node")),
+		0644))
+	
+	// This should be found
+	require.NoError(t, os.WriteFile(
+		filepath.Join(validDir, "pom.xml"),
+		[]byte(fmt.Sprintf(pomContent, "valid")),
+		0644))
+	
+	ctx := context.Background()
+	props := searchForProperties(ctx, tmpDir, "")
+	
+	// Should only find the property from the valid directory
+	assert.Equal(t, "valid", props["test.property"])
+	assert.Len(t, props, 1)
+}
+
+func TestAnalyzeProjectPathWithNonPomXMLFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Create various XML files with different names
+	files := map[string]string{
+		"pom.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <artifactId>main</artifactId>
+    <version>1.0.0</version>
+    <properties>
+        <main.property>main-value</main.property>
+    </properties>
+</project>`,
+		"parent-pom.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <artifactId>parent</artifactId>
+    <properties>
+        <parent.property>parent-value</parent.property>
+    </properties>
+</project>`,
+		"dependencies.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <artifactId>deps</artifactId>
+    <properties>
+        <deps.property>deps-value</deps.property>
+    </properties>
+</project>`,
+		"not-a-pom.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <setting>value</setting>
+</configuration>`,
+		"build.xml": `<?xml version="1.0" encoding="UTF-8"?>
+<project name="ant-project">
+    <target name="build"/>
+</project>`,
+	}
+	
+	for filename, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, filename), []byte(content), 0644))
+	}
+	
+	ctx := context.Background()
+	result, err := AnalyzeProjectPath(ctx, filepath.Join(tmpDir, "pom.xml"))
+	require.NoError(t, err)
+	
+	// Should find properties from all valid POM files regardless of name
+	assert.Contains(t, result.Properties, "main.property")
+	assert.Contains(t, result.Properties, "parent.property")
+	assert.Contains(t, result.Properties, "deps.property")
+	
+	// Should not have properties from non-POM XML files
+	assert.NotContains(t, result.Properties, "setting")
+}

--- a/pkg/analyzer_test.go
+++ b/pkg/analyzer_test.go
@@ -1,0 +1,305 @@
+package pkg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainguard-dev/gopom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeProject(t *testing.T) {
+	tests := []struct {
+		name               string
+		project            *gopom.Project
+		expectedDeps       int
+		expectedPropDeps   int
+		expectedProps      int
+		expectedPropCounts map[string]int
+	}{
+		{
+			name: "project with property-based dependencies",
+			project: &gopom.Project{
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"netty.version": "4.1.94.Final",
+						"slf4j.version": "1.7.30",
+					},
+				},
+				Dependencies: &[]gopom.Dependency{
+					{
+						GroupID:    "io.netty",
+						ArtifactID: "netty-handler",
+						Version:    "${netty.version}",
+					},
+					{
+						GroupID:    "io.netty",
+						ArtifactID: "netty-codec",
+						Version:    "${netty.version}",
+					},
+					{
+						GroupID:    "org.slf4j",
+						ArtifactID: "slf4j-api",
+						Version:    "${slf4j.version}",
+					},
+					{
+						GroupID:    "junit",
+						ArtifactID: "junit",
+						Version:    "4.13.2",
+					},
+				},
+			},
+			expectedDeps:     4,
+			expectedPropDeps: 3,
+			expectedProps:    2,
+			expectedPropCounts: map[string]int{
+				"netty.version": 2,
+				"slf4j.version": 1,
+			},
+		},
+		{
+			name: "project with dependency management",
+			project: &gopom.Project{
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"jackson.version": "2.15.2",
+					},
+				},
+				DependencyManagement: &gopom.DependencyManagement{
+					Dependencies: &[]gopom.Dependency{
+						{
+							GroupID:    "com.fasterxml.jackson.core",
+							ArtifactID: "jackson-databind",
+							Version:    "${jackson.version}",
+						},
+						{
+							GroupID:    "com.fasterxml.jackson.core",
+							ArtifactID: "jackson-core",
+							Version:    "${jackson.version}",
+						},
+					},
+				},
+			},
+			expectedDeps:     2,
+			expectedPropDeps: 2,
+			expectedProps:    1,
+			expectedPropCounts: map[string]int{
+				"jackson.version": 2,
+			},
+		},
+		{
+			name: "project with no properties",
+			project: &gopom.Project{
+				Dependencies: &[]gopom.Dependency{
+					{
+						GroupID:    "org.apache.commons",
+						ArtifactID: "commons-lang3",
+						Version:    "3.12.0",
+					},
+				},
+			},
+			expectedDeps:       1,
+			expectedPropDeps:   0,
+			expectedProps:      0,
+			expectedPropCounts: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			result, err := AnalyzeProject(ctx, tt.project)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedDeps, len(result.Dependencies), "unexpected number of dependencies")
+
+			propDepsCount := 0
+			for _, dep := range result.Dependencies {
+				if dep.UsesProperty {
+					propDepsCount++
+				}
+			}
+			assert.Equal(t, tt.expectedPropDeps, propDepsCount, "unexpected number of property-based dependencies")
+
+			assert.Equal(t, tt.expectedProps, len(result.Properties), "unexpected number of properties")
+
+			for prop, count := range tt.expectedPropCounts {
+				assert.Equal(t, count, result.PropertyUsageCounts[prop], "unexpected usage count for property %s", prop)
+			}
+		})
+	}
+}
+
+func TestShouldUseProperty(t *testing.T) {
+	result := &AnalysisResult{
+		Dependencies: map[string]*DependencyInfo{
+			"io.netty:netty-handler": {
+				GroupID:      "io.netty",
+				ArtifactID:   "netty-handler",
+				Version:      "${netty.version}",
+				UsesProperty: true,
+				PropertyName: "netty.version",
+			},
+			"junit:junit": {
+				GroupID:      "junit",
+				ArtifactID:   "junit",
+				Version:      "4.13.2",
+				UsesProperty: false,
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		groupID        string
+		artifactID     string
+		expectProperty bool
+		propertyName   string
+	}{
+		{
+			name:           "dependency with property",
+			groupID:        "io.netty",
+			artifactID:     "netty-handler",
+			expectProperty: true,
+			propertyName:   "netty.version",
+		},
+		{
+			name:           "dependency without property",
+			groupID:        "junit",
+			artifactID:     "junit",
+			expectProperty: false,
+			propertyName:   "",
+		},
+		{
+			name:           "non-existent dependency",
+			groupID:        "org.example",
+			artifactID:     "not-found",
+			expectProperty: false,
+			propertyName:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useProperty, propName := result.ShouldUseProperty(tt.groupID, tt.artifactID)
+			assert.Equal(t, tt.expectProperty, useProperty)
+			assert.Equal(t, tt.propertyName, propName)
+		})
+	}
+}
+
+func TestPatchStrategy(t *testing.T) {
+	ctx := context.Background()
+
+	result := &AnalysisResult{
+		Dependencies: map[string]*DependencyInfo{
+			"io.netty:netty-handler": {
+				GroupID:      "io.netty",
+				ArtifactID:   "netty-handler",
+				Version:      "${netty.version}",
+				UsesProperty: true,
+				PropertyName: "netty.version",
+			},
+			"io.netty:netty-codec": {
+				GroupID:      "io.netty",
+				ArtifactID:   "netty-codec",
+				Version:      "${netty.version}",
+				UsesProperty: true,
+				PropertyName: "netty.version",
+			},
+			"junit:junit": {
+				GroupID:      "junit",
+				ArtifactID:   "junit",
+				Version:      "4.13.2",
+				UsesProperty: false,
+			},
+		},
+		Properties: map[string]string{
+			"netty.version": "4.1.94.Final",
+		},
+	}
+
+	patches := []Patch{
+		{
+			GroupID:    "io.netty",
+			ArtifactID: "netty-handler",
+			Version:    "4.1.118.Final",
+		},
+		{
+			GroupID:    "junit",
+			ArtifactID: "junit",
+			Version:    "4.13.3",
+		},
+		{
+			GroupID:    "org.example",
+			ArtifactID: "new-dep",
+			Version:    "1.0.0",
+		},
+	}
+
+	directPatches, propertyPatches := PatchStrategy(ctx, result, patches)
+
+	// Should have 2 direct patches (junit update and new dependency)
+	assert.Len(t, directPatches, 2)
+
+	// Should have 1 property update (netty.version)
+	assert.Len(t, propertyPatches, 1)
+	assert.Equal(t, "4.1.118.Final", propertyPatches["netty.version"])
+
+	// Verify direct patches
+	foundJunit := false
+	foundNewDep := false
+	for _, p := range directPatches {
+		if p.GroupID == "junit" && p.ArtifactID == "junit" {
+			foundJunit = true
+			assert.Equal(t, "4.13.3", p.Version)
+		}
+		if p.GroupID == "org.example" && p.ArtifactID == "new-dep" {
+			foundNewDep = true
+			assert.Equal(t, "1.0.0", p.Version)
+		}
+	}
+	assert.True(t, foundJunit, "junit patch not found")
+	assert.True(t, foundNewDep, "new dependency patch not found")
+}
+
+func TestGetAffectedDependencies(t *testing.T) {
+	result := &AnalysisResult{
+		Dependencies: map[string]*DependencyInfo{
+			"io.netty:netty-handler": {
+				GroupID:      "io.netty",
+				ArtifactID:   "netty-handler",
+				UsesProperty: true,
+				PropertyName: "netty.version",
+			},
+			"io.netty:netty-codec": {
+				GroupID:      "io.netty",
+				ArtifactID:   "netty-codec",
+				UsesProperty: true,
+				PropertyName: "netty.version",
+			},
+			"org.slf4j:slf4j-api": {
+				GroupID:      "org.slf4j",
+				ArtifactID:   "slf4j-api",
+				UsesProperty: true,
+				PropertyName: "slf4j.version",
+			},
+		},
+	}
+
+	affected := result.GetAffectedDependencies("netty.version")
+	assert.Len(t, affected, 2)
+
+	for _, dep := range affected {
+		assert.Equal(t, "io.netty", dep.GroupID)
+		assert.Contains(t, []string{"netty-handler", "netty-codec"}, dep.ArtifactID)
+	}
+
+	affectedSlf4j := result.GetAffectedDependencies("slf4j.version")
+	assert.Len(t, affectedSlf4j, 1)
+	assert.Equal(t, "org.slf4j", affectedSlf4j[0].GroupID)
+
+	affectedNone := result.GetAffectedDependencies("non.existent")
+	assert.Len(t, affectedNone, 0)
+}

--- a/pkg/patch.go
+++ b/pkg/patch.go
@@ -36,6 +36,7 @@ type Patch struct {
 	Type       string `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
+
 type PropertyList struct {
 	Properties []PropertyPatch `json:"properties" yaml:"properties"`
 }


### PR DESCRIPTION
Add analyzer to detect when dependencies use property references
      {property.name} and apply appropriate patch strategy.
    
      - Analyzes dependencies and dependencyManagement sections
      - Tracks property usage across all dependencies
      - Adds 'pombump analyze' CLI command for analysis and patch generation

This allows for the generation of pombump-deps and pombump-properties files based on analysis output and makes it easier to debug automation to see why something didn't get bumped. 

This will be used in automation to fix issue where automation creates deps file but instead should be creating/updating properties files. 