### PR TITLE
docs: add deprecation notice for pombump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pombump
 
+> **Deprecated:** pombump is no longer maintained. Use
+> [omnibump](https://github.com/chainguard-dev/omnibump) instead.
+
 Programmatically manipulate maven (pom.xml) dependencies.
 
 # Overview

--- a/cmd/pombump/root.go
+++ b/cmd/pombump/root.go
@@ -28,7 +28,7 @@ func New() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pombump <file-to-bump>",
-		Short: "pombump cli",
+		Short: "pombump cli (deprecated, use omnibump instead)",
 		Args:  cobra.ExactArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Simple log writer setup (replace apko log.Writer)
@@ -58,6 +58,8 @@ func New() *cobra.Command {
 				level = charmlog.InfoLevel
 			}
 			slog.SetDefault(slog.New(charmlog.NewWithOptions(out, charmlog.Options{ReportTimestamp: true, Level: level})))
+
+			slog.Warn("pombump is deprecated and no longer maintained, use omnibump instead: https://github.com/chainguard-dev/omnibump")
 
 			return nil
 		},


### PR DESCRIPTION
pombump has been superseded and is no longer maintained, but the README and CLI gave no indication of this to users, leaving them without a clear path to a supported alternative.

This adds a deprecation banner to the README and a runtime warning printed on every CLI invocation, both pointing users to omnibump (https://github.com/chainguard-dev/omnibump) as the replacement, and updates the command's short description to reflect the deprecated status.